### PR TITLE
Update Rider.cs to use ApplicationSupport folder

### DIFF
--- a/src/DiffEngine/Implementation/Rider.cs
+++ b/src/DiffEngine/Implementation/Rider.cs
@@ -26,7 +26,8 @@ static partial class Implementation
                     "rider",
                     launchArguments,
                     "/Applications/Rider.app/Contents/MacOS/",
-                    "/usr/local/bin/"),
+                    "/usr/local/bin/",
+                    "~/Library/Application Support/JetBrains/Toolbox/scripts"),
                 Linux: new(
                     "rider.sh",
                     launchArguments,


### PR DESCRIPTION
This adds another path to where to call Rider from - https://www.jetbrains.com/help/rider/Working_with_the_IDE_Features_from_Command_Line.html#macos-scripts